### PR TITLE
allow the recombination prior to be the full beta prior

### DIFF
--- a/R/sample_dist_island.R
+++ b/R/sample_dist_island.R
@@ -17,14 +17,18 @@ NULL
 #' @param samples the number of samples required from the posterior after burnin. Defaults to 100.
 #' @param burnin  the number of samples to discard for burnin. Defaults to 10.
 #' @param thin    the number of iterations per sample taken. Defaults to 100.
-#' @param priors - a list of priors for the fit. Defaults to 1,1.
+#' @param priors - a list of priors for the fit. Defaults to 1,c(1,1).
 #' @param data optional data frame from which to take variables in \code{formula} and \code{sequence}.
 #' @return an object of class island which derives from sampling_dist.
 #' @seealso \code{\link{st_fit}}, \code{\link{print.sample_dist}}, \code{\link{plot.sample_dist}}, \code{\link{summary.sample_dist}}
-st_fit_island <- function(formula, sequences, non_primary = "Human", samples = 100, burnin = 10, thin = 100, priors = list(migration=1,recombination=1), data) {
+st_fit_island <- function(formula, sequences, non_primary = "Human", samples = 100, burnin = 10, thin = 100, priors = list(migration=1,recombination=c(1,1)), data) {
   mod.terms = terms(formula, data=data)
   mod.frame = model.frame(formula, data=data)
   allele.frame = model.frame(sequences, data=data)
+
+  if (length(priors$recombination) != 2) {
+    stop("Beta prior on priors$recombination must be length 2")
+  }
 
   if (attr(mod.terms, "response") == 0)
     stop("formula needs a left hand side")

--- a/man/st_fit_island.Rd
+++ b/man/st_fit_island.Rd
@@ -6,7 +6,7 @@
 \usage{
 st_fit_island(formula, sequences, non_primary = "Human", samples = 100,
   burnin = 10, thin = 100, priors = list(migration = 1, recombination
-  = 1), data)
+  = c(1, 1)), data)
 }
 \arguments{
 \item{formula}{A formula of the form Source ~ Genotype}
@@ -22,7 +22,7 @@ but P(ST | source) will be computed for these STs in addition to those observed 
 
 \item{thin}{the number of iterations per sample taken. Defaults to 100.}
 
-\item{priors}{- a list of priors for the fit. Defaults to 1,1.}
+\item{priors}{- a list of priors for the fit. Defaults to 1,c(1,1).}
 
 \item{data}{optional data frame from which to take variables in \code{formula} and \code{sequence}.}
 }

--- a/src/asymmetric_island.h
+++ b/src/asymmetric_island.h
@@ -42,7 +42,7 @@ public:
   void initialise(Rcpp::IntegerMatrix isolates);
 
 	// mcmc6f infers M and R from seqs of known origin, sampling nsamples after nburnin samples, with given thinning
-	void mcmc6f(const double beta, const double gamma_, const int samples, const int burnin, const int thin);
+	void mcmc6f(const double beta, const Rcpp::NumericVector &gamma_, const int samples, const int burnin, const int thin);
 
 	~Island() {
 		/* free memory */

--- a/src/island_model.cpp
+++ b/src/island_model.cpp
@@ -14,9 +14,8 @@ List island(IntegerMatrix isolates, NumericVector beta_migration, NumericVector 
   island.initialise(isolates);
 
   double beta  = beta_migration[0];
-  double gamma = gamma_recombination[0];
 
-  island.mcmc6f(beta, gamma, samples, burnin, thin);
+  island.mcmc6f(beta, gamma_recombination, samples, burnin, thin);
 
   List out;
   out["hum_lik"] = island.human_likelihoods;


### PR DESCRIPTION
This extends the prior for the recombination parameter to the full Beta(a, b) set. Previously it was using Beta(a,a) which is definitely not what is wanted to limit recombination. To limit it low, set a to 1 and b to (say) 999 - the mean is then 1/1000.

Checks:

``` r
library(islandR)
library(tidyverse)
#> Registered S3 method overwritten by 'rvest':
#>   method            from
#>   read_xml.response xml2

# tiny dataset for testing
test <- manawatu %>% group_by(Source) %>% slice(1:2) %>% ungroup()

# params for beta dist
beta_params <- c(99,1)

# Fit the sequence type distribution using the island model
st = st_fit(formula = Source ~ ST,
            non_primary = "Human",
            data = test,
            method="island",
            sequences = ~ ASP + GLN + GLT + GLY + PGM + TKT + UNC,
            priors = list(migration = 1, recombination = beta_params), samples=10000)
#> Maximum ST is 3299 total isolates is 8
#> Number of STs is 10 number of humans is 10 Number of loci is 7 Number of groups is 4

# check outcome variable
st$evolution_params %>% select(starts_with("R")) %>% gather(Source, Value) %>%
  ggplot(aes(x=Value)) + geom_density() + facet_wrap(~Source) +
  stat_function(fun = dbeta, args=list(shape1=beta_params[1], shape2 = beta_params[2]), col='red')
```

![](https://i.imgur.com/erV5Mdi.png)

<sup>Created on 2019-10-25 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>