### PR TITLE
Split mutation migration

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -5,7 +5,7 @@ log_lik <- function(humans, phi, p) {
     .Call('_islandR_log_lik', PACKAGE = 'islandR', humans, phi, p)
 }
 
-island <- function(isolates, beta_migration, gamma_recombination, samples = 100L, burnin = 10L, thin = 100L) {
-    .Call('_islandR_island', PACKAGE = 'islandR', isolates, beta_migration, gamma_recombination, samples, burnin, thin)
+island <- function(isolates, beta_migration, gamma_mutation, gamma_recombination, samples = 100L, burnin = 10L, thin = 100L) {
+    .Call('_islandR_island', PACKAGE = 'islandR', isolates, beta_migration, gamma_mutation, gamma_recombination, samples, burnin, thin)
 }
 

--- a/R/sample_dist_island.R
+++ b/R/sample_dist_island.R
@@ -105,7 +105,8 @@ st_fit_island <- function(formula, sequences, non_primary = "Human", samples = 1
 
   # assign names to the evolution traces
   colnames(out$evolution) <- c("Iteration",
-                               apply(as.matrix(expand.grid("A",1:(length(source_names)+1),1:length(source_names)))[,c(1,3,2)], 1, paste0, collapse=""),
+                               apply(as.matrix(expand.grid("A",1:length(source_names),1:length(source_names)))[,c(1,3,2)], 1, paste0, collapse=""),
+                               paste0("M", 1:length(source_names)),
                                paste0("R", 1:length(source_names)),
                                "Likelihood")
 

--- a/R/sample_dist_island.R
+++ b/R/sample_dist_island.R
@@ -17,17 +17,20 @@ NULL
 #' @param samples the number of samples required from the posterior after burnin. Defaults to 100.
 #' @param burnin  the number of samples to discard for burnin. Defaults to 10.
 #' @param thin    the number of iterations per sample taken. Defaults to 100.
-#' @param priors - a list of priors for the fit. Defaults to 1,c(1,1).
+#' @param priors - a list of priors for the fit. Defaults to 1,c(1,1),c(1,1).
 #' @param data optional data frame from which to take variables in \code{formula} and \code{sequence}.
 #' @return an object of class island which derives from sampling_dist.
 #' @seealso \code{\link{st_fit}}, \code{\link{print.sample_dist}}, \code{\link{plot.sample_dist}}, \code{\link{summary.sample_dist}}
-st_fit_island <- function(formula, sequences, non_primary = "Human", samples = 100, burnin = 10, thin = 100, priors = list(migration=1,recombination=c(1,1)), data) {
+st_fit_island <- function(formula, sequences, non_primary = "Human", samples = 100, burnin = 10, thin = 100, priors = list(migration=1,mutation=c(1,1),recombination=c(1,1)), data) {
   mod.terms = terms(formula, data=data)
   mod.frame = model.frame(formula, data=data)
   allele.frame = model.frame(sequences, data=data)
 
   if (length(priors$recombination) != 2) {
     stop("Beta prior on priors$recombination must be length 2")
+  }
+  if (length(priors$mutation) != 2) {
+    stop("Beta prior on priors$mutation must be length 2")
   }
 
   if (attr(mod.terms, "response") == 0)
@@ -90,7 +93,13 @@ st_fit_island <- function(formula, sequences, non_primary = "Human", samples = 1
   island.mat = as.matrix(rbind(source.frame, type.frame))
 
   # run the island model
-  out = island(island.mat, beta_migration = priors$migration, gamma_recombination = priors$recombination, samples = samples, burnin = burnin, thin = thin)
+  out = island(island.mat,
+               beta_migration = priors$migration,
+               gamma_mutation = priors$mutation,
+               gamma_recombination = priors$recombination,
+               samples = samples,
+               burnin = burnin,
+               thin = thin)
 
   # now regenerate useful summary information... (in future assign names in C++ land?) Also
   # need to change output in C++ land so it gives all types rather than duplicates and only

--- a/man/st_fit_island.Rd
+++ b/man/st_fit_island.Rd
@@ -5,8 +5,8 @@
 \title{Fit the sampling distribution of genotypes to sources using the assymmetric island model.}
 \usage{
 st_fit_island(formula, sequences, non_primary = "Human", samples = 100,
-  burnin = 10, thin = 100, priors = list(migration = 1, recombination
-  = c(1, 1)), data)
+  burnin = 10, thin = 100, priors = list(migration = 1, mutation =
+  c(1, 1), recombination = c(1, 1)), data)
 }
 \arguments{
 \item{formula}{A formula of the form Source ~ Genotype}
@@ -22,7 +22,7 @@ but P(ST | source) will be computed for these STs in addition to those observed 
 
 \item{thin}{the number of iterations per sample taken. Defaults to 100.}
 
-\item{priors}{- a list of priors for the fit. Defaults to 1,c(1,1).}
+\item{priors}{- a list of priors for the fit. Defaults to 1,c(1,1),c(1,1).}
 
 \item{data}{optional data frame from which to take variables in \code{formula} and \code{sequence}.}
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -19,25 +19,26 @@ BEGIN_RCPP
 END_RCPP
 }
 // island
-List island(IntegerMatrix isolates, NumericVector beta_migration, NumericVector gamma_recombination, int samples, int burnin, int thin);
-RcppExport SEXP _islandR_island(SEXP isolatesSEXP, SEXP beta_migrationSEXP, SEXP gamma_recombinationSEXP, SEXP samplesSEXP, SEXP burninSEXP, SEXP thinSEXP) {
+List island(IntegerMatrix isolates, NumericVector beta_migration, NumericVector gamma_mutation, NumericVector gamma_recombination, int samples, int burnin, int thin);
+RcppExport SEXP _islandR_island(SEXP isolatesSEXP, SEXP beta_migrationSEXP, SEXP gamma_mutationSEXP, SEXP gamma_recombinationSEXP, SEXP samplesSEXP, SEXP burninSEXP, SEXP thinSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< IntegerMatrix >::type isolates(isolatesSEXP);
     Rcpp::traits::input_parameter< NumericVector >::type beta_migration(beta_migrationSEXP);
+    Rcpp::traits::input_parameter< NumericVector >::type gamma_mutation(gamma_mutationSEXP);
     Rcpp::traits::input_parameter< NumericVector >::type gamma_recombination(gamma_recombinationSEXP);
     Rcpp::traits::input_parameter< int >::type samples(samplesSEXP);
     Rcpp::traits::input_parameter< int >::type burnin(burninSEXP);
     Rcpp::traits::input_parameter< int >::type thin(thinSEXP);
-    rcpp_result_gen = Rcpp::wrap(island(isolates, beta_migration, gamma_recombination, samples, burnin, thin));
+    rcpp_result_gen = Rcpp::wrap(island(isolates, beta_migration, gamma_mutation, gamma_recombination, samples, burnin, thin));
     return rcpp_result_gen;
 END_RCPP
 }
 
 static const R_CallMethodDef CallEntries[] = {
     {"_islandR_log_lik", (DL_FUNC) &_islandR_log_lik, 3},
-    {"_islandR_island", (DL_FUNC) &_islandR_island, 6},
+    {"_islandR_island", (DL_FUNC) &_islandR_island, 7},
     {NULL, NULL, 0}
 };
 

--- a/src/asymmetric_island.cpp
+++ b/src/asymmetric_island.cpp
@@ -210,13 +210,12 @@ void Island::mcmc6f(const double beta, const NumericVector &gamma_, const int sa
 	NumericArray3 b = calc_b(A);
 
 	NumericMatrix r(ng,2);	///< Reparameterised per-group recombination rates
-	NumericMatrix R(ng,2);  ///< R[grp,1:2] = r[grp,1:2]/sum(r[grp,1:2])
 	for (int i = 0; i < ng; i++) {
 	  for (int j = 0; j < 2; j++) {
 		  r(i,j) = R::rgamma(gamma_[j], 1.0);
 	  }
 	}
-	calc_R(r, R);
+	NumericMatrix R = normalise_rows(r);
 
 	/* Storage for likelihoods */
 	double loglikelihood = known_source_loglik(A, b, M, R);
@@ -412,15 +411,16 @@ void Island::calc_A(NumericMatrix &a, NumericMatrix &A, NumericMatrix &M) {
   }
 }
 
-// Assumes R is correctly sized
-void Island::calc_R(NumericMatrix &r, NumericMatrix &R) {
-  for (int i = 0; i < r.nrow(); i++) {
-    R(i,_) = normalise(r(i,_));
-  }
-}
-
 NumericVector Island::normalise(const NumericVector &x) {
   return x / sum(x);
+}
+
+NumericMatrix Island::normalise_rows(const NumericMatrix &x) {
+  NumericMatrix X = no_init(x.nrow(), x.ncol());
+  for (int i = 0; i < x.nrow(); i++) {
+    X(i,_) = normalise(x(i,_));
+  }
+  return X;
 }
 
 Island::NumericArray3 Island::calc_b(const NumericMatrix &A) {

--- a/src/asymmetric_island.cpp
+++ b/src/asymmetric_island.cpp
@@ -12,14 +12,15 @@ using namespace Rcpp;
 /* Computes the log likelihood of ST j in source i */
 logdouble Island::known_source_loglik_ij(int i, int j, const NumericMatrix &A, const NumericArray3 &b, const NumericMatrix &R) {
   double punique = A(i,ng);
+  double mu_i = A(i,ng); // mutation rate
   std::vector<double> psame(nloc);
   std::vector<double> pdiff(nloc);
   for (int l = 0; l < nloc; l++) {
     int allele = MLST[i](j, l);
     double ac = acount[i][l][allele];
     double ac_ = (ac*(double)size[i]-1.0)/(double)(size[i]-1);
-    double bk = b[i][l][allele] - A(i,i)*ac + A(i,i)*ac_;
-    double b_ = R(i,0) * bk + R(i,1) * (1.0-A(i,ng));// if no rec then must be same as CF (barring mutation)
+    double bk = (1-mu_i)*b[i][l][allele] - A(i,i)*ac + A(i,i)*ac_;
+    double b_ = R(i,0) * bk + R(i,1) * (1.0-mu_i);// if no rec then must be same as CF (barring mutation)
     if(fabs(b_)<1.0e-7) {
       b_ = 0.0;
     }
@@ -76,11 +77,11 @@ double Island::likHi6(const int id, const int i, const NumericMatrix &A, const N
 	std::vector<double> pdiff(nloc);
 	std::vector<double> psame(nloc);
 
-	double puniq = A(i,ng); // mutation rate
+	double mu = A(i,ng);    // mutation rate
 	for (int l = 0; l < nloc; l++) {
 		int human_allele = human(id, l);
-		pdiff[l] = std::max(R(i,0) * b[i][l][human_allele],0.0);
-		psame[l] = std::max(R(i,0) * b[i][l][human_allele] + R(i,1) * (1.0-A(i,ng)),0.0);
+		pdiff[l] = std::max((1.0 - mu)*R(i,0) * b[i][l][human_allele],0.0);
+		psame[l] = std::max((1.0 - mu)*R(i,0) * b[i][l][human_allele] + R(i,1) * (1.0 - mu),0.0);
 	}
 	double lik = 0.0;
 	for (int ii = 0; ii < ng; ii++) {								// Cycle through source of the clonal frame
@@ -92,7 +93,7 @@ double Island::likHi6(const int id, const int i, const NumericMatrix &A, const N
 			bool* SAME = same[id][ii][jj];
 			for(int l=0; l<nloc; l++, SAME++) {
 				if (HUMAN_UNIQUE[l]) {						// new allele (allow some rounding error)
-					l_jj *= puniq;
+					l_jj *= mu;
 				}
 				else if(*SAME) {						// previously observed and same as CF
 					l_jj *= psame[l];
@@ -416,7 +417,7 @@ Island::NumericArray3 Island::calc_b(const NumericMatrix &A) {
       for(size_t k = 0; k < acount[i][j].size(); k++) {
         b[i][j][k] = 0.0;
         for(int l = 0; l < ng; l++) {
-          b[i][j][k] += acount[l][j][k] * A(i,l);
+          b[i][j][k] += acount[l][j][k] * A(i,l) / (1.0 - A(i,ng));
           //					bk[i][j][k] += (acount[l][j][k]*(double)size[l]-1.0)/(double)(size[l]-1) * a[i][l];
         }
       }

--- a/src/asymmetric_island.cpp
+++ b/src/asymmetric_island.cpp
@@ -19,7 +19,7 @@ logdouble Island::known_source_loglik_ij(int i, int j, const NumericMatrix &A, c
     int allele = MLST[i](j, l);
     double ac = acount[i][l][allele];
     double ac_ = (ac*(double)size[i]-1.0)/(double)(size[i]-1);
-    double bk = (1-mu_i)*b[i][l][allele] - A(i,i)*ac + A(i,i)*ac_;
+    double bk = (1-mu_i)*b[i][l][allele] - (1-mu_i)*A(i,i)*ac + (1-mu_i)*A(i,i)*ac_;
     double b_ = R(i,0) * bk + R(i,1) * (1.0-mu_i);// if no rec then must be same as CF (barring mutation)
     if(fabs(b_)<1.0e-7) {
       b_ = 0.0;
@@ -34,7 +34,7 @@ logdouble Island::known_source_loglik_ij(int i, int j, const NumericMatrix &A, c
   }
   std::vector<logdouble> l_j(ng);
   for (int ii = 0; ii < ng; ii++) {						//	Cycle through source of the clonal frame
-    double mii = A(i,ii)/(1.0-A(i,ng));
+    double mii = A(i,ii);
     std::vector<logdouble> l_ii(nST[ii]);      // allocate the vector
     for (int jj = 0; jj < nST[ii]; jj++) {				//	Cycle through each ST from that source
       double ncopiesjj = (i==ii && j==jj) ? ABUN[ii][jj]-std::min(ABUN[ii][jj],1.0)
@@ -85,7 +85,7 @@ double Island::likHi6(const int id, const int i, const NumericMatrix &A, const N
 	}
 	double lik = 0.0;
 	for (int ii = 0; ii < ng; ii++) {								// Cycle through source of the clonal frame
-		double mii = A(i,ii)/(1.0-A(i,ng));
+		double mii = A(i,ii);
 		double l_ii = 0.0;
 		for (int jj = 0; jj <nST[ii]; jj++) {
 			double l_jj = mii;						//	Cycle through each ST from that source
@@ -274,6 +274,8 @@ void Island::mcmc6f(const double beta, const NumericVector &gamma_, const int sa
 					ar_prop[id2] = ar[id1];
 					NumericMatrix A_prop(clone(A));
 					A_prop(popid,_) = normalise(ar_prop);
+					for (int i = 0; i < ng; i++)
+					  A_prop(popid, i) /= (1-A_prop(popid, ng));
 					double logalpha = 0.0;
 					// Prior ratio equals 1 because prior is symmetric
 					// Hastings ratio equals 1 because proposal is symmetric
@@ -302,6 +304,8 @@ void Island::mcmc6f(const double beta, const NumericVector &gamma_, const int sa
 
 					NumericMatrix A_prop(clone(A));
 					A_prop(popid,_) = normalise(ar_prop);
+					for (int i = 0; i < ng; i++)
+					  A_prop(popid, i) /= (1-A_prop(popid, ng));
 					// Prior-Hastings ratio
 					double logalpha = ar[id] - ar_prop[id];
 					logalpha += beta * log(ar_prop[id]/ar[id]);
@@ -395,6 +399,12 @@ void Island::calc_A(NumericMatrix &a, NumericMatrix &A) {
   for (int i = 0; i < a.nrow(); i++) {
     A(i,_) = normalise(a(i,_));
   }
+  // rescale out the mutation
+  for (int i = 0; i < a.nrow(); i++) {
+    for (int j = 0; j < a.ncol()-1; j++) {
+      A(i,j) /= (1-A(i,ng));
+    }
+  }
 }
 
 // Assumes R is correctly sized
@@ -417,7 +427,7 @@ Island::NumericArray3 Island::calc_b(const NumericMatrix &A) {
       for(size_t k = 0; k < acount[i][j].size(); k++) {
         b[i][j][k] = 0.0;
         for(int l = 0; l < ng; l++) {
-          b[i][j][k] += acount[l][j][k] * A(i,l) / (1.0 - A(i,ng));
+          b[i][j][k] += acount[l][j][k] * A(i,l);
           //					bk[i][j][k] += (acount[l][j][k]*(double)size[l]-1.0)/(double)(size[l]-1) * a[i][l];
         }
       }

--- a/src/asymmetric_island.h
+++ b/src/asymmetric_island.h
@@ -80,7 +80,6 @@ public:
 	logdouble known_source_loglik_ij(int i, int j, const Rcpp::NumericMatrix &A, const NumericArray3 &b, const Rcpp::NumericMatrix &M, const Rcpp::NumericMatrix &R);
 
 	NumericArray3 calc_b(const Rcpp::NumericMatrix &A);
-	void calc_A(Rcpp::NumericMatrix &a, Rcpp::NumericMatrix &A, Rcpp::NumericMatrix &M);
 	Rcpp::NumericVector normalise(const Rcpp::NumericVector &x);
 	Rcpp::NumericMatrix normalise_rows(const Rcpp::NumericMatrix &x);
 	void precalc();

--- a/src/asymmetric_island.h
+++ b/src/asymmetric_island.h
@@ -75,12 +75,12 @@ public:
 	int multinom(const Rcpp::NumericVector &p);
 	int sample(int n);
 
-	double likHi6(const int id, const int i, const Rcpp::NumericMatrix &A, const NumericArray3 &b, const Rcpp::NumericMatrix &R);
-	double known_source_loglik(const Rcpp::NumericMatrix &A, const NumericArray3 &b, const Rcpp::NumericMatrix &R);
-	logdouble known_source_loglik_ij(int i, int j, const Rcpp::NumericMatrix &A, const NumericArray3 &b, const Rcpp::NumericMatrix &R);
+	double likHi6(const int id, const int i, const Rcpp::NumericMatrix &A, const NumericArray3 &b, const Rcpp::NumericMatrix &M, const Rcpp::NumericMatrix &R);
+	double known_source_loglik(const Rcpp::NumericMatrix &A, const NumericArray3 &b, const Rcpp::NumericMatrix &M, const Rcpp::NumericMatrix &R);
+	logdouble known_source_loglik_ij(int i, int j, const Rcpp::NumericMatrix &A, const NumericArray3 &b, const Rcpp::NumericMatrix &M, const Rcpp::NumericMatrix &R);
 
 	NumericArray3 calc_b(const Rcpp::NumericMatrix &A);
-	void calc_A(Rcpp::NumericMatrix &a, Rcpp::NumericMatrix &A);
+	void calc_A(Rcpp::NumericMatrix &a, Rcpp::NumericMatrix &A, Rcpp::NumericMatrix &M);
 	void calc_R(Rcpp::NumericMatrix &r, Rcpp::NumericMatrix &R);
 	Rcpp::NumericVector normalise(const Rcpp::NumericVector &x);
 	void precalc();

--- a/src/asymmetric_island.h
+++ b/src/asymmetric_island.h
@@ -42,7 +42,7 @@ public:
   void initialise(Rcpp::IntegerMatrix isolates);
 
 	// mcmc6f infers M and R from seqs of known origin, sampling nsamples after nburnin samples, with given thinning
-	void mcmc6f(const double beta, const Rcpp::NumericVector &gamma_, const int samples, const int burnin, const int thin);
+	void mcmc6f(const double beta, const Rcpp::NumericVector &gamma_m, const Rcpp::NumericVector &gamma_r, const int samples, const int burnin, const int thin);
 
 	~Island() {
 		/* free memory */

--- a/src/asymmetric_island.h
+++ b/src/asymmetric_island.h
@@ -81,8 +81,8 @@ public:
 
 	NumericArray3 calc_b(const Rcpp::NumericMatrix &A);
 	void calc_A(Rcpp::NumericMatrix &a, Rcpp::NumericMatrix &A, Rcpp::NumericMatrix &M);
-	void calc_R(Rcpp::NumericMatrix &r, Rcpp::NumericMatrix &R);
 	Rcpp::NumericVector normalise(const Rcpp::NumericVector &x);
+	Rcpp::NumericMatrix normalise_rows(const Rcpp::NumericMatrix &x);
 	void precalc();
 };
 

--- a/src/island_model.cpp
+++ b/src/island_model.cpp
@@ -7,7 +7,7 @@ using namespace Rcpp;
 // run island model
 
 // [[Rcpp::export]]
-List island(IntegerMatrix isolates, NumericVector beta_migration, NumericVector gamma_recombination, int samples = 100, int burnin = 10, int thin = 100) {
+List island(IntegerMatrix isolates, NumericVector beta_migration, NumericVector gamma_mutation, NumericVector gamma_recombination, int samples = 100, int burnin = 10, int thin = 100) {
 
   // create model class
   Island island;
@@ -15,7 +15,7 @@ List island(IntegerMatrix isolates, NumericVector beta_migration, NumericVector 
 
   double beta  = beta_migration[0];
 
-  island.mcmc6f(beta, gamma_recombination, samples, burnin, thin);
+  island.mcmc6f(beta, gamma_mutation, gamma_recombination, samples, burnin, thin);
 
   List out;
   out["hum_lik"] = island.human_likelihoods;


### PR DESCRIPTION
Splits the a/A matrices in the island model that are combined migration/mutation into separate migration (a/A) and mutation (m/M) matrices. Exposes new priors on mutation.

NOTE: attribution and genotype distributions will differ a little with this change from previous, due to the prior change (likely not noticeable with n>100 source isolates).