### PR TITLE
Mutation recombination linear model

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -5,7 +5,7 @@ log_lik <- function(humans, phi, p) {
     .Call('_islandR_log_lik', PACKAGE = 'islandR', humans, phi, p)
 }
 
-island <- function(isolates, beta_migration, gamma_mutation, gamma_recombination, samples = 100L, burnin = 10L, thin = 100L) {
-    .Call('_islandR_island', PACKAGE = 'islandR', isolates, beta_migration, gamma_mutation, gamma_recombination, samples, burnin, thin)
+island <- function(isolates, beta_migration, gamma_mutation, gamma_recombination, X_mutation, X_recombination, samples = 100L, burnin = 10L, thin = 100L) {
+    .Call('_islandR_island', PACKAGE = 'islandR', isolates, beta_migration, gamma_mutation, gamma_recombination, X_mutation, X_recombination, samples, burnin, thin)
 }
 

--- a/man/st_fit_island.Rd
+++ b/man/st_fit_island.Rd
@@ -6,7 +6,8 @@
 \usage{
 st_fit_island(formula, sequences, non_primary = "Human", samples = 100,
   burnin = 10, thin = 100, priors = list(migration = 1, mutation =
-  c(1, 1), recombination = c(1, 1)), data)
+  c(1, 1), recombination = c(1, 1)), control = list(mutation = "source",
+  recombination = "source"), data)
 }
 \arguments{
 \item{formula}{A formula of the form Source ~ Genotype}
@@ -23,6 +24,9 @@ but P(ST | source) will be computed for these STs in addition to those observed 
 \item{thin}{the number of iterations per sample taken. Defaults to 100.}
 
 \item{priors}{- a list of priors for the fit. Defaults to 1,c(1,1),c(1,1).}
+
+\item{control}{- a list of model control information. Defaults to mutation="source", recombination="source". Specify "constant" for
+a single probability across all sources.}
 
 \item{data}{optional data frame from which to take variables in \code{formula} and \code{sequence}.}
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -19,8 +19,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // island
-List island(IntegerMatrix isolates, NumericVector beta_migration, NumericVector gamma_mutation, NumericVector gamma_recombination, int samples, int burnin, int thin);
-RcppExport SEXP _islandR_island(SEXP isolatesSEXP, SEXP beta_migrationSEXP, SEXP gamma_mutationSEXP, SEXP gamma_recombinationSEXP, SEXP samplesSEXP, SEXP burninSEXP, SEXP thinSEXP) {
+List island(IntegerMatrix isolates, NumericVector beta_migration, NumericVector gamma_mutation, NumericVector gamma_recombination, NumericMatrix X_mutation, NumericMatrix X_recombination, int samples, int burnin, int thin);
+RcppExport SEXP _islandR_island(SEXP isolatesSEXP, SEXP beta_migrationSEXP, SEXP gamma_mutationSEXP, SEXP gamma_recombinationSEXP, SEXP X_mutationSEXP, SEXP X_recombinationSEXP, SEXP samplesSEXP, SEXP burninSEXP, SEXP thinSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -28,17 +28,19 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< NumericVector >::type beta_migration(beta_migrationSEXP);
     Rcpp::traits::input_parameter< NumericVector >::type gamma_mutation(gamma_mutationSEXP);
     Rcpp::traits::input_parameter< NumericVector >::type gamma_recombination(gamma_recombinationSEXP);
+    Rcpp::traits::input_parameter< NumericMatrix >::type X_mutation(X_mutationSEXP);
+    Rcpp::traits::input_parameter< NumericMatrix >::type X_recombination(X_recombinationSEXP);
     Rcpp::traits::input_parameter< int >::type samples(samplesSEXP);
     Rcpp::traits::input_parameter< int >::type burnin(burninSEXP);
     Rcpp::traits::input_parameter< int >::type thin(thinSEXP);
-    rcpp_result_gen = Rcpp::wrap(island(isolates, beta_migration, gamma_mutation, gamma_recombination, samples, burnin, thin));
+    rcpp_result_gen = Rcpp::wrap(island(isolates, beta_migration, gamma_mutation, gamma_recombination, X_mutation, X_recombination, samples, burnin, thin));
     return rcpp_result_gen;
 END_RCPP
 }
 
 static const R_CallMethodDef CallEntries[] = {
     {"_islandR_log_lik", (DL_FUNC) &_islandR_log_lik, 3},
-    {"_islandR_island", (DL_FUNC) &_islandR_island, 7},
+    {"_islandR_island", (DL_FUNC) &_islandR_island, 9},
     {NULL, NULL, 0}
 };
 

--- a/src/asymmetric_island.cpp
+++ b/src/asymmetric_island.cpp
@@ -193,7 +193,12 @@ void append_traces(int iter, NumericMatrix &A, NumericMatrix &M, NumericMatrix &
 }
 
 /* This version uses the clonal frame version of the likelihood */
-void Island::mcmc6f(const double beta, const NumericVector &gamma_m, const NumericVector &gamma_r, const int samples, const int burnin, const int thin) {
+void Island::mcmc6f(const double beta,
+                    const NumericVector &gamma_m,
+                    const NumericVector &gamma_r,
+                    const NumericMatrix &X_m,
+                    const NumericMatrix &X_r,
+                    const int samples, const int burnin, const int thin) {
 	precalc();
 
   /* Initialize the random number generator */

--- a/src/asymmetric_island.cpp
+++ b/src/asymmetric_island.cpp
@@ -209,21 +209,21 @@ void Island::mcmc6f(const double beta, const NumericVector &gamma_m, const Numer
 	NumericMatrix A = normalise_rows(a);
 	NumericArray3 b = calc_b(A);
 
-	NumericMatrix m(ng,2);	///< Reparameterised per-group mutation rates
-	for (int i = 0; i < ng; i++) {
+	NumericMatrix m(X_m.ncol(),2);	///< Reparameterised mutation rates
+	for (int i = 0; i < m.nrow(); i++) {
 	  for (int j = 0; j < 2; j++) {
 	    m(i,j) = R::rgamma(gamma_m[j], 1.0);
 	  }
 	}
-	NumericMatrix M = normalise_rows(m);
+	NumericMatrix M = normalise_rows(matrix_product(X_m, m));
 
-	NumericMatrix r(ng,2);	///< Reparameterised per-group recombination rates
-	for (int i = 0; i < ng; i++) {
+	NumericMatrix r(X_r.ncol(),2);	///< Reparameterised recombination rates
+	for (int i = 0; i < r.nrow(); i++) {
 	  for (int j = 0; j < 2; j++) {
 	    r(i,j) = R::rgamma(gamma_r[j], 1.0);
 	  }
 	}
-	NumericMatrix R = normalise_rows(r);
+	NumericMatrix R = normalise_rows(matrix_product(X_r, r));
 
 	/* Storage for likelihoods */
 	double loglikelihood = known_source_loglik(A, b, M, R);
@@ -333,22 +333,22 @@ void Island::mcmc6f(const double beta, const NumericVector &gamma_m, const Numer
 					break;
 				}
 			  case 2: { // update M (switching move)
-				  int popid = sample(ng);	// Choose the source for which to change the mutation matrix
-				  // Need only update one row of a
+				  int rowid = sample(m.nrow());	// Choose the source for which to change the mutation matrix
+				  // Need only update one row of m
 				  NumericMatrix m_prop(clone(m));
-				  m_prop(popid, 0) = m(popid, 1);
-				  m_prop(popid, 1) = m(popid, 0);
-				  NumericMatrix M_prop = normalise_rows(m_prop);
+				  m_prop(rowid, 0) = m(rowid, 1);
+				  m_prop(rowid, 1) = m(rowid, 0);
+				  NumericMatrix M_prop = normalise_rows(matrix_product(X_m, m_prop));
 				  // Prior ratio equals 1 if gamma prior is symmetric, otherwise
-				  double logalpha = (gamma_m[1] - gamma_m[0])*log(m(popid,0)/m(popid,1));
+				  double logalpha = (gamma_m[1] - gamma_m[0])*log(m(rowid,0)/m(rowid,1));
 				  // Hastings ratio equals 1 because proposal is symmetric
 				  // Likelihood ratio
 				  double newloglik = known_source_loglik(A, b, M_prop, R);
 
 				  logalpha += newloglik - loglikelihood;
 				  if (logalpha >= 0.0 || R::runif(0, 1) < exp(logalpha)) {	// accept
-				    m(popid,_) = m_prop(popid,_);
-				    M(popid,_) = M_prop(popid,_);
+				    m(rowid,_) = m_prop(rowid,_);
+				    M = M_prop;
 				    loglikelihood = newloglik;
 				    accept(2,0)++;
 				  }
@@ -358,22 +358,22 @@ void Island::mcmc6f(const double beta, const NumericVector &gamma_m, const Numer
 				  break;
 				}
 			  case 3: { // update M (log normal random walk)
-      	  int popid = sample(ng);	// Choose the source for which to change the mutation matrix
+      	  int rowid = sample(m.nrow());	// Choose the source for which to change the mutation matrix
       	  int id = sample(2);	    // Principal element of mig matrix to change
       	  // Need only update one row of m
       	  NumericMatrix m_prop(clone(m));
-      	  m_prop(popid,id) = R::rlnorm(log(m(popid,id)), sigma_m);
-      	  NumericMatrix M_prop = normalise_rows(m_prop);
+      	  m_prop(rowid,id) = R::rlnorm(log(m(rowid,id)), sigma_m);
+      	  NumericMatrix M_prop = normalise_rows(matrix_product(X_m, m_prop));
       	  // Prior-Hastings ratio
-      	  double logalpha = m(popid,id) - m_prop(popid,id);
-      	  logalpha += gamma_m[id] * log(m_prop(popid,id)/m(popid,id));
+      	  double logalpha = m(rowid,id) - m_prop(rowid,id);
+      	  logalpha += gamma_m[id] * log(m_prop(rowid,id)/m(rowid,id));
       	  // Likelihood ratio
       	  double newloglik = known_source_loglik(A, b, M_prop, R);
 
       	  logalpha += newloglik - loglikelihood;
       	  if (logalpha >= 0.0 || R::runif(0, 1) < exp(logalpha)) {	// accept
-      	    m(popid,_) = m_prop(popid,_);
-      	    M(popid,_) = M_prop(popid,_);
+      	    m(rowid,_) = m_prop(rowid,_);
+      	    M = M_prop;
       	    loglikelihood = newloglik;
       	    accept(3,0)++;
       	  }
@@ -383,24 +383,23 @@ void Island::mcmc6f(const double beta, const NumericVector &gamma_m, const Numer
       	  break;
 			  }
 				case 4: {// update r (switching move)
-					int popid = sample(ng);
+					int rowid = sample(r.nrow());
 				  // Need only update one row of r
-				  NumericMatrix::Row rr = r(popid,_);
-				  NumericVector rr_prop = rr;
-					rr_prop[0] = rr[1];
-					rr_prop[1] = rr[0];
-					NumericMatrix R_prop(clone(R));
-					R_prop(popid,_) = normalise(rr_prop);
+				  NumericMatrix r_prop(clone(r));
+				  r_prop(rowid, 0) = r(rowid, 1);
+				  r_prop(rowid, 1) = r(rowid, 0);
+				  NumericMatrix R_prop = normalise_rows(matrix_product(X_r, r_prop));
+
 					// prior is gamma, so we have log(prod(dgamma(rev(x), r, rate=1))/prod(dgamma(x, r, rate=1)))
-					double logalpha = (gamma_r[1] - gamma_r[0])*log(rr[0]/rr[1]);
+					double logalpha = (gamma_r[1] - gamma_r[0])*log(r(rowid,0)/r(rowid,1));
 					// Symmetric proposal (swap)
 					// Likelihood ratio
 					double newloglik = known_source_loglik(A, b, M, R_prop);
 
 					logalpha += newloglik - loglikelihood;
 					if (logalpha >= 0.0 || R::runif(0, 1) < exp(logalpha)) {	// accept
-						rr = rr_prop;
-						R(popid,_) = R_prop(popid,_);
+					  r(rowid,_) = r_prop(rowid,_);
+					  R = R_prop;
 						loglikelihood = newloglik;
 						accept(4,0)++;
 					}
@@ -410,24 +409,22 @@ void Island::mcmc6f(const double beta, const NumericVector &gamma_m, const Numer
 					break;
 				}
 				case 5:	{// update r (log-normal move)
-					int popid = sample(ng);	// Choose the source for which to change the "rec" parameter
+					int rowid = sample(r.nrow());	// Choose the source for which to change the "rec" parameter
 					int id = sample(2);			// Change one or other of the gamma components
 					// Need only update one row of r
-					NumericMatrix::Row rr = r(popid,_);
-					NumericVector rr_prop = rr;
-					rr_prop[id] = R::rlnorm(log(rr[id]), sigma_r);
-					NumericMatrix R_prop = clone(R);
-					R_prop(popid,_) = normalise(rr_prop);
+					NumericMatrix r_prop(clone(r));
+					r_prop(rowid,id) = R::rlnorm(log(r(rowid,id)), sigma_r);
+					NumericMatrix R_prop = normalise_rows(matrix_product(X_r, r_prop));
 					// Prior-Hastings ratio
-					double logalpha = rr[id] - rr_prop[id];
-					logalpha += gamma_r[id] * log(rr_prop[id]/rr[id]);
+					double logalpha = r(rowid,id) - r_prop(rowid,id);
+					logalpha += gamma_r[id] * log(r_prop(rowid,id)/r(rowid,id));
 					// Likelihood ratio
 					double newloglik = known_source_loglik(A, b, M, R_prop);
 
 					logalpha += newloglik - loglikelihood;
 					if (logalpha >= 0.0 || R::runif(0, 1) < exp(logalpha)) {	// accept
-						rr = rr_prop;
-						R(popid, _) = R_prop(popid, _);
+					  r(rowid,_) = r_prop(rowid,_);
+						R = R_prop;
 						loglikelihood = newloglik;
 						accept(5,0)++;
 					}
@@ -464,6 +461,16 @@ NumericMatrix Island::normalise_rows(const NumericMatrix &x) {
   NumericMatrix X = no_init(x.nrow(), x.ncol());
   for (int i = 0; i < x.nrow(); i++) {
     X(i,_) = normalise(x(i,_));
+  }
+  return X;
+}
+
+NumericMatrix Island::matrix_product(const NumericMatrix &x, const NumericMatrix &y) {
+  NumericMatrix X = no_init(x.nrow(), y.ncol());
+  for (int i = 0; i < x.nrow(); i++) {
+    for (int j = 0; j < y.ncol(); j++) {
+      X(i,j) = sum(x(i,_) * y(_,j));
+    }
   }
   return X;
 }

--- a/src/asymmetric_island.h
+++ b/src/asymmetric_island.h
@@ -43,7 +43,12 @@ public:
   void initialise(Rcpp::IntegerMatrix isolates);
 
 	// mcmc6f infers M and R from seqs of known origin, sampling nsamples after nburnin samples, with given thinning
-	void mcmc6f(const double beta, const Rcpp::NumericVector &gamma_m, const Rcpp::NumericVector &gamma_r, const int samples, const int burnin, const int thin);
+	void mcmc6f(const double beta,
+             const Rcpp::NumericVector &gamma_m,
+             const Rcpp::NumericVector &gamma_r,
+             const Rcpp::NumericMatrix &X_m,
+             const Rcpp::NumericMatrix &X_r,
+             const int samples, const int burnin, const int thin);
 
 	~Island() {
 		/* free memory */

--- a/src/asymmetric_island.h
+++ b/src/asymmetric_island.h
@@ -83,6 +83,7 @@ public:
 	NumericArray3 calc_b(const Rcpp::NumericMatrix &A);
 	Rcpp::NumericVector normalise(const Rcpp::NumericVector &x);
 	Rcpp::NumericMatrix normalise_rows(const Rcpp::NumericMatrix &x);
+	Rcpp::NumericMatrix matrix_product(const Rcpp::NumericMatrix &x, const Rcpp::NumericMatrix &y);
 	void precalc();
 };
 

--- a/src/island_model.cpp
+++ b/src/island_model.cpp
@@ -7,7 +7,13 @@ using namespace Rcpp;
 // run island model
 
 // [[Rcpp::export]]
-List island(IntegerMatrix isolates, NumericVector beta_migration, NumericVector gamma_mutation, NumericVector gamma_recombination, int samples = 100, int burnin = 10, int thin = 100) {
+List island(IntegerMatrix isolates,
+            NumericVector beta_migration,
+            NumericVector gamma_mutation,
+            NumericVector gamma_recombination,
+            NumericMatrix X_mutation,
+            NumericMatrix X_recombination,
+            int samples = 100, int burnin = 10, int thin = 100) {
 
   // create model class
   Island island;
@@ -15,7 +21,7 @@ List island(IntegerMatrix isolates, NumericVector beta_migration, NumericVector 
 
   double beta  = beta_migration[0];
 
-  island.mcmc6f(beta, gamma_mutation, gamma_recombination, samples, burnin, thin);
+  island.mcmc6f(beta, gamma_mutation, gamma_recombination, X_mutation, X_recombination, samples, burnin, thin);
 
   List out;
   out["hum_lik"] = island.human_likelihoods;


### PR DESCRIPTION
This implements a linear model for recombination and mutation. This will allow the ability to set a common mutation or recombination parameter across sources.

You can use a model with the same recombination probability across sources by adding
`control = list(recombination = 'constant')` to st_fit